### PR TITLE
Fix prediction model docstring

### DIFF
--- a/rugbyPoolApp/models.py
+++ b/rugbyPoolApp/models.py
@@ -49,7 +49,7 @@ class match(baseObject):
 
 
 class prediction(baseObject):
-	"""docstring for prediction"""
+	"""Represents a user's score prediction for a match."""
 
 	user = models.ForeignKey(User, on_delete=models.CASCADE)
 	prediction_match = models.ForeignKey(match, on_delete=models.CASCADE)


### PR DESCRIPTION
## Summary
- replace placeholder docstring in `prediction` model with a descriptive text

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6846a3a4bc14832aa3977b33ab5c8358